### PR TITLE
Prevent crash when icon does not exist in Utils::getIconByName.

### DIFF
--- a/src/gui/addressbox.cpp
+++ b/src/gui/addressbox.cpp
@@ -4,14 +4,16 @@
 
 #include "plugin.hpp"
 #include "settings.hpp"
+#include "utils.hpp"
 
 Addressbox::Addressbox() :
-mGoButton("Go!") {
+mGoButton() {
     this->mGoButton.signal_clicked().connect(sigc::mem_fun(*this, &Addressbox::on_go_button_click));
     this->mGoButton.set_margin_top(1);
     this->mGoButton.set_margin_bottom(1);
     this->mGoButton.set_margin_left(1);
     this->mGoButton.set_margin_right(1);
+    this->mGoButton.set_image(*Gtk::manage(new Gtk::Image(Utils::getIconByName("go-next", 16))));
     this->pack_start(this->mAddressBar, true, true);
     this->pack_start(this->mGoButton, false, true);
 }

--- a/src/gui/searchbar.cpp
+++ b/src/gui/searchbar.cpp
@@ -4,7 +4,7 @@
 
 Searchbar::Searchbar() {
     auto primaryIcon = this->property_primary_icon_pixbuf();
-    primaryIcon = Utils::getIconByName("gtk-find", 16);
+    primaryIcon = Utils::getIconByName("system-search", 16);
 }
 
 void Searchbar::setTreeModelFilter(FilebrowserFilter* filter) {

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -40,8 +40,15 @@ std::string Utils::escapeTooltip(std::string tooltip) {
 }
 
 Glib::RefPtr<Gdk::Pixbuf> Utils::getIconByName(const char* name, uint size) {
-    auto theme = Gtk::IconTheme::get_default();
-    return theme->load_icon(name, size);
+    Glib::RefPtr<Gtk::IconTheme> theme = Gtk::IconTheme::get_default();
+    Gtk::IconInfo icon = theme->lookup_icon(name, size);
+    if (icon) {
+        return icon.load_icon();
+    } else {
+        Glib::RefPtr<Gdk::Pixbuf> invalidIcon = Gdk::Pixbuf::create(Gdk::COLORSPACE_RGB, true, 8, size, size);
+        invalidIcon->fill(0xFF00FFFF);
+        return invalidIcon;
+    }
 }
 
 std::vector<std::string> Utils::createValidExtensions() {


### PR DESCRIPTION
Utils::getIconByName now returns icon filled with #FF00FFFF if icon can not be found. This will prevent crash and allows proceeding with the missing icon while also showing some placeholder (instead of blank space that could be confusing in some cases).
Changed icon to comply with freedesktop icon naming specification - this fixes the original problem causing exception. Reference: https://specifications.freedesktop.org/icon-naming-spec/icon-naming-spec-latest.html
Added icon instead of "Go!" in address bar button - every button in deadbeef has icon instead of a text, this makes it more consistent.