### PR TITLE
Reworked treeview loading

### DIFF
--- a/include/gui/addressbox.hpp
+++ b/include/gui/addressbox.hpp
@@ -3,12 +3,15 @@
 #include <gtkmm.h>
 
 #include "treefilebrowser.hpp"
+#include "filebrowserfilter.hpp"
 
 class Addressbox : public Gtk::HBox
 {
 public:
     void setTreeFilebrowser(TreeFilebrowser* newTreeFilebrowser);
     void setAddress(std::string newAddres);
+    void updateProgress(float progress);
+    void initialize(Gtk::TreeView* treeview, Glib::RefPtr<FilebrowserFilter>);
     std::string getAddress();
 
     /**
@@ -19,16 +22,34 @@ public:
      * @return New corrected string.
      */
     std::string makeValidPath(std::string path);
+
+    // Called from the worker thread.
+    void notify();
+
     Addressbox();
     ~Addressbox();
 private:
     Gtk::Button mGoButton;
     Gtk::Entry mAddressBar;
     TreeFilebrowser* mTreeFilebrowser;
+    Gtk::TreeView* mTreeView;
+    Glib::RefPtr<FilebrowserFilter> mFilebrowserFilter;
     std::string mAddress;
+
+    bool inProgress = false;
+
+    Glib::Dispatcher mDispatcher;
+    void onNotify();
+    void updateProgress();
 
     /**
      * Gets called when pressing Go! button
      */
     void on_go_button_click();
+
+    struct ProgressBarData {
+        Gtk::Entry* bar;
+        float progress;
+    };
+    static void setProgressBar(ProgressBarData* data);
 };

--- a/include/gui/treefilebrowser.hpp
+++ b/include/gui/treefilebrowser.hpp
@@ -2,17 +2,26 @@
 
 #include <gtkmm.h>
 #include <filesystem>
+#include <thread>
+#include <atomic>
+#include <memory>
+
 
 #include "modelcolumns.hpp"
+
+class Addressbox;
 
 class TreeFilebrowser : public Gtk::TreeStore {
 public:
     ModelColumns mModelColumns;
     static Glib::RefPtr<TreeFilebrowser> create();
     void setNeedleState(bool newState);
-    void setTreeView(Gtk::TreeView* treeview);
+    void initialize(Gtk::TreeView* treeview, Addressbox* addressbox);
     void setIconSize(uint newValue);
+    void refreshThread();
+    void stopThread();
 
+    void getProgress(float* progress) const;
 
     /**
      * Sets new root directory and refreshes tree.
@@ -26,17 +35,25 @@ public:
      * If you want to filter things out, see filebrowserfilter instead.
      */
     void refreshTree();
+
+
 private:
     std::filesystem::path mTreeDirectory;
     Gtk::TreeView* mTreeView;
+    Addressbox* mAddressbox;
 
     uint mIconSize = 32;
 
-    bool mIsNeedleSet = false;
+    bool mIsNeedleSet = true;
     bool refreshLock = false;
 
     TreeFilebrowser();
     ~TreeFilebrowser();
+
+    float progressCount = 0;
+    float progressIteration = 1;
+    std::atomic<float> threadProgress = 0;
+    
 
     /**
      * Function to refresh tree via second thread.
@@ -45,6 +62,9 @@ private:
      */
     static void threadedRefreshTree(void* data);
 
+    std::thread* mRefreshThread;
+    std::atomic<bool> mRefreshThreadRun = true;
+
     /**
      * Recursively creates TreeModel at path.
      * 
@@ -52,6 +72,8 @@ private:
      * @param parent Parent of newly created entries(used in recursion).
      */
     void initialize(std::filesystem::path path, Gtk::TreeRow* parent = nullptr);
+
+    void findChildren(std::filesystem::path path, Gtk::TreeNodeChildren child);
 
     /**
      * If tree would be empty, this adds line indicating that the directory is empty or hidden.

--- a/include/plugin.hpp
+++ b/include/plugin.hpp
@@ -1,5 +1,9 @@
 #pragma once
 
 #include "deadbeef/deadbeef.h"
+#include <string>
+
+
+void pluginLog(int level, std::string message);
 
 extern DB_functions_t* deadbeef;

--- a/include/plugin/settings.hpp
+++ b/include/plugin/settings.hpp
@@ -3,3 +3,5 @@
 #define FBR_DEFAULT_PATH "filebrowser_reborn.default_path"
 #define FBR_ICON_SIZE "filebrowser_reborn.icon_size"
 #define FBR_DOUBLECLICK_REPLACE "filebrowser_reborn.doubleclick_replace"
+#define FBR_LOADCOVER_SONG "filebrowser_reborn.loadcover_song"
+#define FBR_LOADCOVER_ALBUM "filebrowser_reborn.loadcover_song"

--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -54,6 +54,8 @@ public:
      * @return Vector of all supported extensions
      */
     static std::vector<std::string> createValidExtensions();
+
+    static Glib::RefPtr<Gdk::Pixbuf> getCoverPicture(std::string filename, int size);
 private:
     Utils();
     ~Utils();

--- a/src/gui/container.cpp
+++ b/src/gui/container.cpp
@@ -42,7 +42,8 @@ void Container::initialize() {
 
 void Container::buildTreeview() {
     this->mTreeView.set_model(mFilebrowserFilter);
-    this->mTreeFilebrowser->setTreeView(&this->mTreeView);
+    this->mAddressbox.initialize(&mTreeView, mFilebrowserFilter);
+    this->mTreeFilebrowser->initialize(&this->mTreeView, &this->mAddressbox);
 
     this->mTreeView.append_column("Icon", this->mTreeFilebrowser->mModelColumns.mColumnIcon);
     this->mTreeView.append_column("Name", this->mTreeFilebrowser->mModelColumns.mColumnName);

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,5 +1,6 @@
 dependencies = [
     dependency('gtkmm-3.0'),
+    dependency('taglib')
 ]
 
 # Apparently deadbeef can't be found with pkg-conf

--- a/src/plugin.cpp
+++ b/src/plugin.cpp
@@ -7,7 +7,9 @@ static DB_misc_t plugin;
 
 const char config_dialog[] =
 "property \"Icon size: \" spinbtn[24,48,2] " FBR_ICON_SIZE " \"32\" ;\n"
-"property \"Doubleclick replace: \" checkbox " FBR_DOUBLECLICK_REPLACE " \"0\" ;\n"
+"property \"Doubleclick replace playlist content \" checkbox " FBR_DOUBLECLICK_REPLACE " \"0\" ;\n"
+"property \"Load song cover art from metadata (this will take a long time for the first time) \" checkbox " FBR_LOADCOVER_SONG " \"0\" ;\n"
+"property \"Load folder cover art from metadata (this will take a long time for the first time) \" checkbox " FBR_LOADCOVER_ALBUM " \"0\" ;\n"
 ;
 
 extern "C" 
@@ -29,4 +31,8 @@ DB_plugin_t* ddb_misc_filebrowser_reborn_load(DB_functions_t* api) {
     plugin.plugin.configdialog = config_dialog;
 
     return DB_PLUGIN(&plugin.plugin);
+}
+
+void pluginLog(int level, std::string message) {
+    deadbeef->log_detailed (&plugin.plugin, level, message.c_str());
 }

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -2,28 +2,65 @@
 
 #include "deadbeef/deadbeef.h"
 
+#include <flacpicture.h>
+#include <flacfile.h>
+#include <id3v2tag.h>
+#include <id3v1tag.h>
+#include <attachedpictureframe.h>
+#include <mpegfile.h>
+#include <wavfile.h>
+#include <oggfile.h>
+#include <vorbisfile.h>
+
+#include <boost/algorithm/string.hpp>
+
 #include "filebrowser.hpp"
 #include "plugin.hpp"
+#include "settings.hpp"
 
 Glib::RefPtr<Gdk::Pixbuf> Utils::getIcon(std::filesystem::path path, uint size) {
     Glib::RefPtr<Gdk::Pixbuf> icon;
+    
+    auto currentPath = Utils::createCachePath(path, size);
 
     if (std::filesystem::is_directory(path)) {
         std::string outputName;
-        auto currentPath = Utils::createCachePath(path, size);
         if (std::filesystem::exists(currentPath)) {
-            icon = Gdk::Pixbuf::create_from_file(currentPath);
+            return Gdk::Pixbuf::create_from_file(currentPath);
         } else if (Filebrowser::hasFile(path, {"cover.jpg", "cover.png", "front.jpg", "front.png"}, &outputName)) {
             icon = Gdk::Pixbuf::create_from_file(outputName, -1, size, true);
             icon->save(currentPath, "png");
-        } else {
-            icon = Utils::getIconByName("folder", size);
+            return icon;
+        } else if (deadbeef->conf_get_int(FBR_LOADCOVER_ALBUM, 0) == 1) {
+            auto fileVec = Filebrowser::getFileList(path, true, false);
+            if (fileVec.size() > 0) {
+                auto file = fileVec.front();
+                if (file.is_regular_file() && file.file_size() > 0) {
+                    try {
+                        icon = Utils::getCoverPicture(file.path(), size);
+                        icon->save(currentPath, "png");
+                        return icon;
+                    } catch (std::exception &e) {
+                        return getIconByName("folder", size);
+                    }
+                }
+            }
         }
-    } else {
-        icon = Utils::getIconByName("audio-x-generic", size);
+        return Utils::getIconByName("folder", size);
     }
 
-    return icon;
+    if (std::filesystem::exists(currentPath)) {
+        return Gdk::Pixbuf::create_from_file(currentPath);
+    } else if (deadbeef->conf_get_int(FBR_LOADCOVER_ALBUM, 0) == 1) {
+        try {
+            icon = Utils::getCoverPicture(path, size);
+            icon->save(currentPath, "png");
+            return icon;
+        } catch (std::exception &e) {
+            return getIconByName("audio-x-generic", size);
+        }
+    }
+    return Utils::getIconByName("audio-x-generic", size);
 }
 
 std::string Utils::escapeTooltip(std::string tooltip) {
@@ -69,6 +106,8 @@ std::vector<std::string> Utils::createValidExtensions() {
 }
 
 std::filesystem::path Utils::createCachePath(std::filesystem::path path, uint size) {
+    //Also check XDG_CACHE_HOME as first default, home should be fallback or use the deadbeef cache
+    //std::filesystem::path cache = std::filesystem::path(deadbeef->get_system_dir(DDB_SYS_DIR_CACHE));
     std::filesystem::path cache = getenv("HOME");
     cache.append(".cache");
     cache.append(CACHE_PATH + "/icons/" + std::to_string(size) + std::string("/"));
@@ -89,4 +128,149 @@ std::filesystem::path Utils::createCachePath(std::filesystem::path path, uint si
     }
     cache.append(editedPath);
     return cache;
+}
+
+Glib::RefPtr<Gdk::Pixbuf> Utils::getCoverPicture(std::string filename, int size) {
+    std::string fileType = boost::to_lower_copy(filename.substr(filename.rfind(".")+1));
+    
+    if (fileType == "flac") {
+        TagLib::FLAC::File f(filename.c_str());
+        if (f.isValid()) {
+            for(const auto &pic : f.pictureList()) {
+                if (pic->height() > 0) {
+                    unsigned int bufSize = pic->data().size();
+                    guint8 *data = new guint8[bufSize];
+                    memcpy(data, pic->data().data(), bufSize);
+                        
+                    Glib::RefPtr<Gdk::PixbufLoader> loader = Gdk::PixbufLoader::create();
+                    loader->set_size(size, size);
+                    try{
+                        loader->write(data, bufSize);
+                        loader->close();
+                        delete[] data;
+                        return loader->get_pixbuf();
+                    } catch (Glib::Error &e) {
+                        //pluginLog(DDB_LOG_LAYER_INFO, ("Error while loading cover from metadata: %s", e.what().c_str()));
+                        std::cout << "Error while loading cover from metadata: " << e.what() << std::endl;
+                        delete[] data;
+                    }
+                }
+            }
+            if (f.hasID3v2Tag()) {
+                TagLib::ID3v2::Tag *tag = f.ID3v2Tag();
+                TagLib::ID3v2::FrameList frameList = tag->frameListMap()["APIC"];
+                for(const auto &pic : frameList) {
+                    TagLib::ID3v2::AttachedPictureFrame *frame = static_cast<TagLib::ID3v2::AttachedPictureFrame*>(pic);
+                    if (frame->picture().size() > 0) {
+                        unsigned int bufSize = frame->picture().size();
+                        guint8 *data = new guint8[bufSize];
+                        memcpy(data, frame->picture().data(), bufSize);
+                        
+                        Glib::RefPtr<Gdk::PixbufLoader> loader = Gdk::PixbufLoader::create();
+                        loader->set_size(size, size);
+                        try{
+                            loader->write(data, bufSize);
+                            loader->close();
+                            delete[] data;
+                            return loader->get_pixbuf();
+                        } catch (Glib::Error &e) {
+                            //pluginLog(DDB_LOG_LAYER_INFO, ("Error while loading cover from metadata: %s", e.what().c_str()));
+                            std::cout << "Error while loading cover from metadata: " << e.what() << std::endl;
+                            delete[] data;
+                        }
+                    }
+                }
+            }
+        }
+    }
+    if (fileType == "wav") {
+        TagLib::RIFF::WAV::File f(filename.c_str());
+        if (f.isValid()) {
+            if (f.hasID3v2Tag()) {
+                TagLib::ID3v2::Tag *tag = f.ID3v2Tag();
+                TagLib::ID3v2::FrameList frameList = tag->frameListMap()["APIC"];
+                for(const auto &pic : frameList) {
+                    TagLib::ID3v2::AttachedPictureFrame *frame = static_cast<TagLib::ID3v2::AttachedPictureFrame*>(pic);
+                    if (frame->picture().size() > 0) {
+                        unsigned int bufSize = frame->picture().size();
+                        guint8 *data = new guint8[bufSize];
+                        memcpy(data, frame->picture().data(), bufSize);
+                        
+                        Glib::RefPtr<Gdk::PixbufLoader> loader = Gdk::PixbufLoader::create();
+                        loader->set_size(size, size);
+                        try{
+                            loader->write(data, bufSize);
+                            loader->close();
+                            delete[] data;
+                            return loader->get_pixbuf();
+                        } catch (Glib::Error &e) {
+                            //pluginLog(DDB_LOG_LAYER_INFO, ("Error while loading cover from metadata: %s", e.what().c_str()));
+                            std::cout << "Error while loading cover from metadata: " << e.what() << std::endl;
+                            delete[] data;
+                        }
+                    }
+                }
+            }
+        }
+    }
+    if (fileType == "mp3") {
+        TagLib::MPEG::File f(filename.c_str());
+        if (f.isValid()) {
+            if (f.hasID3v2Tag()) {
+                TagLib::ID3v2::Tag *tag = f.ID3v2Tag();
+                TagLib::ID3v2::FrameList frameList = tag->frameListMap()["APIC"];
+                for(const auto &pic : frameList) {
+                    TagLib::ID3v2::AttachedPictureFrame *frame = static_cast<TagLib::ID3v2::AttachedPictureFrame*>(pic);
+                    if (frame->picture().size() > 0) {
+                        unsigned int bufSize = frame->picture().size();
+                        guint8 *data = new guint8[bufSize];
+                        memcpy(data, frame->picture().data(), bufSize);
+                        
+                        Glib::RefPtr<Gdk::PixbufLoader> loader = Gdk::PixbufLoader::create();
+                        loader->set_size(size, size);
+                        try{
+                            loader->write(data, bufSize);
+                            loader->close();
+                            delete[] data;
+                            return loader->get_pixbuf();
+                        } catch (Glib::Error &e) {
+                            //pluginLog(DDB_LOG_LAYER_INFO, ("Error while loading cover from metadata: %s", e.what().c_str()));
+                            std::cout << "Error while loading cover from metadata: " << e.what() << std::endl;
+                            delete[] data;
+                        }
+                    }
+                }
+            }
+        }
+    }
+    if (fileType == "ogg") {
+        TagLib::Ogg::Vorbis::File f(filename.c_str());
+        if (f.isValid()) {
+            if (f.tag()) {
+                TagLib::Ogg::XiphComment *tag = f.tag();
+                TagLib::List<TagLib::FLAC::Picture*> picList = tag->pictureList();
+                for(const auto &pic : picList) {
+                    if (pic->height() > 0) {
+                        unsigned int bufSize = pic->data().size();
+                        guint8 *data = new guint8[bufSize];
+                        memcpy(data, pic->data().data(), bufSize);
+                        
+                        Glib::RefPtr<Gdk::PixbufLoader> loader = Gdk::PixbufLoader::create();
+                        loader->set_size(size, size);
+                        try{
+                            loader->write(data, bufSize);
+                            loader->close();
+                            delete[] data;
+                            return loader->get_pixbuf();
+                        } catch (Glib::Error &e) {
+                            //pluginLog(DDB_LOG_LAYER_INFO, ("Error while loading cover from metadata: %s", e.what().c_str()));
+                            std::cout << "Error while loading cover from metadata: " << e.what() << std::endl;
+                            delete[] data;
+                        }
+                    }
+                }
+            }
+        }
+    }
+    throw std::runtime_error("No cover found");
 }


### PR DESCRIPTION
Prevent crashing when updating files, also shows progress and loads metadata images optionally. Starts using dispatcher for treeview load.
Closes #2 